### PR TITLE
Update instead of update_attributes

### DIFF
--- a/lib/api_logic.rb
+++ b/lib/api_logic.rb
@@ -75,7 +75,7 @@ module ApiLogic
   def update
     raise NotImplementedError unless model_class
 
-    @model.update_attributes(update_attributes)
+    @model.update(update_attributes)
     respond_with @model
   end
 


### PR DESCRIPTION
### Summary
update_attributes is deprecated as of Rails 6 and will be removed in 6.1